### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Setup is pretty simple:
 2. Set up Triggers in iTerm 2 like so:
 
 <pre>
-    Regular expression: \*\*B0100
+    Regular expression: rz waiting to receive.\*\*B0100
     Action: Run Silent Coprocess
     Parameters: /usr/local/bin/iterm2-send-zmodem.sh
 


### PR DESCRIPTION
I encounter a problem  that  when I use rz  with iTerm2 Build 2.9.2015062  it continuously popups the finder window after I have clicked the enter button with any file chosen.I find  that even though the file has been sent to the target file the string "\*\*B0100" still displays on the iterm so the iterm matches the string "\*\*B0100" and triggers again which leads to an infinite loop.
After I change  the Regular expression from "\*\*B0100" to "rz waiting to receive.\*\*B0100" ,the problem is solved.